### PR TITLE
Phase 1: Add visibility control schema for multi-format resume generation

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,258 @@
+# Resume Schema Documentation
+
+This document describes the extended JSON Resume schema used in `resume.json`, including custom visibility controls for multi-format output generation.
+
+## Overview
+
+The `resume.json` file serves as a single source of truth for generating multiple resume formats:
+- **README.md** - GitHub profile with summary and key work experience
+- **PDF CV** - LaTeX-generated professional CV (latest position + master's degrees)
+- **Website** - Full interactive CV website
+
+## Schema Extensions
+
+### Visibility Control
+
+All major sections support a `visibility` field that controls where each entry appears:
+
+```json
+{
+  "visibility": ["readme", "pdf", "website"]
+}
+```
+
+**Valid visibility values:**
+- `"readme"` - Entry appears in README.md
+- `"pdf"` - Entry appears in LaTeX-generated PDF
+- `"website"` - Entry appears on the CV website
+
+**Note:** An entry can have multiple visibility targets. If an entry should appear everywhere, include all three values.
+
+## Sections with Visibility Support
+
+### Work Experience (`work`)
+
+Each work experience entry supports the `visibility` field:
+
+```json
+{
+  "work": [
+    {
+      "name": "Company Name",
+      "position": "Job Title",
+      "location": "City, Country",
+      "url": "https://example.com",
+      "startDate": "YYYY-MM-DD",
+      "endDate": "YYYY-MM-DD",
+      "summary": "Brief description",
+      "highlights": ["Achievement 1", "Achievement 2"],
+      "visibility": ["readme", "pdf", "website"]
+    }
+  ]
+}
+```
+
+**Visibility Guidelines:**
+- **README**: First 4-5 most recent/relevant positions
+- **PDF**: Only the most recent position (current role)
+- **Website**: All positions (complete work history)
+
+### Education (`education`)
+
+Each education entry supports the `visibility` field:
+
+```json
+{
+  "education": [
+    {
+      "institution": "University Name",
+      "url": "https://university.edu",
+      "area": "Field of Study",
+      "studyType": "Degree Type",
+      "startDate": "YYYY-MM-DD",
+      "endDate": "YYYY-MM-DD",
+      "score": "GPA / Grade",
+      "summary": "Description",
+      "courses": ["Course 1", "Course 2"],
+      "keywords": ["Skill 1", "Skill 2"],
+      "highlights": ["Achievement 1", "Achievement 2"],
+      "visibility": ["pdf", "website"]
+    }
+  ]
+}
+```
+
+**Visibility Guidelines:**
+- **README**: Education section not included in README
+- **PDF**: Only Master's degree programs
+- **Website**: All education (including bachelor's and secondary education)
+
+### Skills (`skills`)
+
+Each skill category supports the `visibility` field:
+
+```json
+{
+  "skills": [
+    {
+      "name": "Skill Category",
+      "level": "Advanced/Intermediate/Beginner",
+      "keywords": ["Technology 1", "Technology 2"],
+      "visibility": ["website"]
+    }
+  ]
+}
+```
+
+**Visibility Guidelines:**
+- **README**: Skills not shown separately (included inline in work descriptions)
+- **PDF**: Skills not shown separately (included inline in work descriptions)
+- **Website**: All skill categories displayed
+
+### Awards (`awards`)
+
+Each award supports the `visibility` field:
+
+```json
+{
+  "awards": [
+    {
+      "title": "Award Name",
+      "date": "YYYY-MM-DD",
+      "awarder": "Organization",
+      "summary": "Description",
+      "visibility": ["website"]
+    }
+  ]
+}
+```
+
+**Visibility Guidelines:**
+- **README**: Awards not included in README
+- **PDF**: Awards not included in PDF
+- **Website**: All awards displayed
+
+### Languages (`languages`)
+
+Each language entry supports the `visibility` field:
+
+```json
+{
+  "languages": [
+    {
+      "language": "Language Name",
+      "fluency": "Proficiency Level",
+      "visibility": ["website"]
+    }
+  ]
+}
+```
+
+**Visibility Guidelines:**
+- **README**: Languages not included in README
+- **PDF**: Languages can be added to sidebar if needed
+- **Website**: All languages displayed
+
+## Sections Without Visibility Control
+
+The following sections apply globally to all formats:
+
+### Basics (`basics`)
+
+Contains personal information used across all formats:
+
+```json
+{
+  "basics": {
+    "name": "Full Name",
+    "label": "Professional Title",
+    "image": "URL to photo",
+    "email": "email@example.com",
+    "phone": "Phone number",
+    "url": "https://website.com",
+    "summary": "Professional summary",
+    "location": {
+      "address": "",
+      "postalCode": "",
+      "city": "City",
+      "countryCode": "XX",
+      "region": "Region"
+    },
+    "profiles": [
+      {
+        "network": "LinkedIn",
+        "username": "username",
+        "url": "https://linkedin.com/in/username"
+      }
+    ]
+  }
+}
+```
+
+**Usage:**
+- **README**: Uses `summary` and `profiles`
+- **PDF**: Uses `name`, `label`, and optionally contact info
+- **Website**: Uses all fields
+
+## Base Schema
+
+This schema extends the [JSON Resume Schema v1.0.0](https://jsonresume.org/schema/) with the `visibility` field. All standard JSON Resume fields remain valid and compatible.
+
+### Validation
+
+When updating `resume.json`, ensure:
+
+1. All `visibility` arrays contain only valid values: `"readme"`, `"pdf"`, or `"website"`
+2. Dates follow ISO 8601 format: `YYYY-MM-DD`
+3. Required fields per JSON Resume schema are present
+4. At least one visibility target is specified for entries you want to appear
+
+### Example Visibility Patterns
+
+**Latest work position (appears everywhere relevant):**
+```json
+"visibility": ["readme", "pdf", "website"]
+```
+
+**Recent but not current position (README and website only):**
+```json
+"visibility": ["readme", "website"]
+```
+
+**Historical position (website only for complete history):**
+```json
+"visibility": ["website"]
+```
+
+**Master's degree (PDF and website):**
+```json
+"visibility": ["pdf", "website"]
+```
+
+**Bachelor's degree or earlier education (website only):**
+```json
+"visibility": ["website"]
+```
+
+## Updating the Resume
+
+When adding or updating resume entries:
+
+1. Add the entry to the appropriate section in `resume.json`
+2. Include the `visibility` field with appropriate targets
+3. Follow the visibility guidelines above
+4. Run validation script: `npm run validate:resume` (once implemented)
+5. Generate outputs: `npm run generate:all` (once implemented)
+
+## Future Enhancements
+
+Potential future additions to the schema:
+- Tag system for more granular filtering (e.g., `"featured"`, `"technical"`)
+- Custom ordering/priority fields
+- Theme/styling preferences per output format
+- Conditional content based on context (e.g., technical vs. business audience)
+
+## Reference
+
+- [JSON Resume Schema](https://jsonresume.org/schema/)
+- [JSON Resume Specification](https://github.com/jsonresume/resume-schema)

--- a/resume.json
+++ b/resume.json
@@ -40,7 +40,8 @@
         "Built data infrastructure and pipelines for analytics platforms",
         "Designed scalable data architectures supporting business growth",
         "Implemented data solutions enabling data-driven decision-making"
-      ]
+      ],
+      "visibility": ["readme", "pdf", "website"]
     },
     {
       "name": "Foodello - Fiksuruoka.fi",
@@ -55,7 +56,8 @@
         "Implemented data transformations in Snowflake data warehouse",
         "Built infrastructure as code using Terraform on GCP",
         "Created business intelligence dashboards using Tableau"
-      ]
+      ],
+      "visibility": ["readme", "website"]
     },
     {
       "name": "Unity Technologies",
@@ -70,7 +72,8 @@
         "Implemented data transformations and models using dbt and Snowflake",
         "Developed workflow orchestration solutions with Apache Airflow",
         "Managed cloud infrastructure on GCP using Terraform"
-      ]
+      ],
+      "visibility": ["readme", "website"]
     },
     {
       "name": "Unity Technologies",
@@ -84,7 +87,8 @@
         "Developed JavaScript and TypeScript applications",
         "Implemented automated testing using Jest",
         "Designed and documented APIs using OpenAPI Specification"
-      ]
+      ],
+      "visibility": ["readme", "website"]
     },
     {
       "name": "Aalto University",
@@ -98,7 +102,8 @@
         "Graded assignments for Methods of Data Mining course",
         "Provided constructive feedback to students",
         "Collaborated with PhD Wilhelmiina Hämäläinen"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "name": "ATECRESA",
@@ -112,7 +117,8 @@
         "Designed and developed scalable e-commerce platform",
         "Built solutions for restaurant sector in Canary Islands",
         "Full-stack development role"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "name": "Universidad de La Laguna",
@@ -127,7 +133,8 @@
         "Developed GeneticsJS, an open-source framework for evolutionary algorithms",
         "Funded by Spanish Education Ministry national collaboration grant",
         "Worked under PhD supervision on software engineering research"
-      ]
+      ],
+      "visibility": ["website"]
     }
   ],
   "volunteer": [],
@@ -153,7 +160,8 @@
         "Part of EIT Digital master's program",
         "Completed thesis: https://github.com/CristianAbrante/masters-thesis-data-science",
         "Course projects on GitHub: Machine Learning, Data Mining, Reinforcement Learning"
-      ]
+      ],
+      "visibility": ["pdf", "website"]
     },
     {
       "institution": "Coventry University",
@@ -171,7 +179,8 @@
         "Worked on real-world healthcare business case",
         "Collaborated with WCS Care Services (UK)",
         "Developed complete business model for proposed solution"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "institution": "Universidad Politécnica de Madrid",
@@ -194,7 +203,8 @@
         "Part of EIT Digital master's program (Year 1)",
         "Combined technical data science with business/entrepreneurship",
         "Foundation in statistical analysis and big data technologies"
-      ]
+      ],
+      "visibility": ["pdf", "website"]
     },
     {
       "institution": "Universidad de La Laguna",
@@ -226,7 +236,8 @@
         "Best academic record of promotion",
         "Strong foundation in algorithms, software engineering, and data science",
         "Technologies: Java, C++, JavaScript, HTML5, CSS3, Git"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "institution": "I.E.S. Lucas Martín Espino",
@@ -242,7 +253,8 @@
         "Grade: 9.81/10 (highest grade)",
         "Obtained with honors",
         "Best academic record of promotion"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "institution": "I.E.S. San Marcos",
@@ -254,7 +266,8 @@
       "summary": "Science and technology track in secondary education.",
       "courses": [],
       "keywords": ["Science", "Technology"],
-      "highlights": []
+      "highlights": [],
+      "visibility": ["website"]
     },
     {
       "institution": "I.E.S. El Tanque",
@@ -270,7 +283,8 @@
         "Grade: 9.55/10 (highest grade)",
         "Obtained with honors",
         "Best academic record of promotion"
-      ]
+      ],
+      "visibility": ["website"]
     }
   ],
   "awards": [
@@ -278,13 +292,15 @@
       "title": "Extraordinary Award for Academic Performance in Bachelor's Degree",
       "date": "2019-11-01",
       "awarder": "Universidad de La Laguna",
-      "summary": "Award obtained for exceptional academic performance in the Bachelor's degree in Computer Science at La Laguna University."
+      "summary": "Award obtained for exceptional academic performance in the Bachelor's degree in Computer Science at La Laguna University.",
+      "visibility": ["website"]
     },
     {
       "title": "Best Project Award - GeneticJS",
       "date": "2019-04-01",
       "awarder": "Oficina de Software Libre - Universidad de La Laguna",
-      "summary": "Special award for best project in the local phase of the Spanish University free software contest, given to the project GeneticJS."
+      "summary": "Special award for best project in the local phase of the Spanish University free software contest, given to the project GeneticJS.",
+      "visibility": ["website"]
     }
   ],
   "certificates": [],
@@ -300,32 +316,38 @@
         "Apache Spark",
         "Apache Druid",
         "Airflow"
-      ]
+      ],
+      "visibility": ["website"]
     },
     {
       "name": "Programming Languages",
       "level": "Advanced",
-      "keywords": ["SQL", "Python", "JavaScript", "TypeScript"]
+      "keywords": ["SQL", "Python", "JavaScript", "TypeScript"],
+      "visibility": ["website"]
     },
     {
       "name": "Cloud & Infrastructure",
       "level": "Advanced",
-      "keywords": ["GCP", "Terraform"]
+      "keywords": ["GCP", "Terraform"],
+      "visibility": ["website"]
     },
     {
       "name": "Analytics & Tools",
       "level": "Intermediate",
-      "keywords": ["Tableau", "Jest", "OpenAPI"]
+      "keywords": ["Tableau", "Jest", "OpenAPI"],
+      "visibility": ["website"]
     }
   ],
   "languages": [
     {
       "language": "Spanish",
-      "fluency": "Native speaker"
+      "fluency": "Native speaker",
+      "visibility": ["website"]
     },
     {
       "language": "English",
-      "fluency": "Full professional proficiency"
+      "fluency": "Full professional proficiency",
+      "visibility": ["website"]
     }
   ],
   "interests": [],


### PR DESCRIPTION
## Summary

This PR implements **Phase 1** of the multi-format resume generation system, adding visibility control to `resume.json` to enable generating multiple resume formats from a single source of truth.

## Changes

### 1. Extended Resume Schema
- Added `visibility` field to all major sections: `work`, `education`, `skills`, `awards`, `languages`
- Visibility values: `"readme"`, `"pdf"`, `"website"`
- Each entry can specify which output formats it should appear in

### 2. Visibility Rules Implemented

**Work Experience:**
- Latest position (ALOHAS): `["readme", "pdf", "website"]`
- Recent positions (Foodello, Unity): `["readme", "website"]`
- Historical positions: `["website"]`

**Education:**
- Master's degrees (Aalto, UPM): `["pdf", "website"]`
- Other education: `["website"]`

**Skills, Awards, Languages:**
- All: `["website"]` (full details on website only)

### 3. Documentation
- Created `SCHEMA.md` with comprehensive documentation
- Explains visibility system and usage guidelines
- Provides examples and best practices
- Documents all extended fields

## Benefits

- Single source of truth in `resume.json`
- Flexible control over what appears in each format
- Maintains data consistency across outputs
- Easy to update and maintain

## Next Steps

This sets the foundation for:
- Phase 2: Generate README.md from JSON
- Phase 3: LaTeX PDF generation
- Phase 4: CI/CD automation
- Phase 5-6: Website creation and deployment

## Testing

The schema changes are non-breaking and backward compatible with JSON Resume v1.0.0.

To validate the changes, you can check:
```bash
# View the updated resume.json structure
cat resume.json

# Review the schema documentation
cat SCHEMA.md
```