### PR TITLE
docs(resume): update ALOHAS role description

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Passionate Data Engineer with a strong foundation in data science, shaped by div
 
 - 👨🏻‍💻 Data Engineer - [`@ALOHAS2020`](https://github.com/ALOHAS2020)  
 *Barcelona, Spain | March 2025 - Present*  
-🛠 **Technologies**: Dagster · dbt · BigQuery
+🛠 **Technologies**: Airbyte · Dagster · dbt · BigQuery · Lightdash · OpenCode · Claude
 
 - 👨🏻‍💻 Data Engineer - [`@Fiksuruoka-fi`](https://github.com/Fiksuruoka-fi)  
 *Helsinki, Finland | October 2023 - February 2025*  

--- a/resume.json
+++ b/resume.json
@@ -35,13 +35,14 @@
       "location": "Barcelona, Catalonia, Spain",
       "url": "https://github.com/ALOHAS2020",
       "startDate": "2025-03-01",
-      "summary": "Designing and implementing scalable data and analytics architectures to drive business insights and decision-making.",
+      "summary": "Built data capabilities in the company from scratch. As the first data hire, I started a modern data platform (Airbyte, Dagster, dbt, BigQuery, Lightdash) that centralized analytics across the company, all powered by AI (OpenCode + Claude).",
       "highlights": [
-        "Built data infrastructure and pipelines for analytics platforms",
-        "Designed scalable data architectures supporting business growth",
-        "Implemented data solutions enabling data-driven decision-making"
+        "First data hire — bootstrapped the entire data function from scratch",
+        "Built a modern data platform with Airbyte, Dagster, dbt, BigQuery, and Lightdash",
+        "Centralized analytics across the company to enable data-driven decision-making",
+        "Leveraged AI-assisted development (OpenCode + Claude) to accelerate delivery"
       ],
-      "technologies": ["Dagster", "dbt", "BigQuery"],
+      "technologies": ["Airbyte", "Dagster", "dbt", "BigQuery", "Lightdash", "OpenCode", "Claude"],
       "visibility": ["readme", "pdf", "website"]
     },
     {


### PR DESCRIPTION
Updates the ALOHAS work entry in `resume.json` (and regenerated `README.md`) to reflect the actual scope of the role.

### Summary
> Built data capabilities in the company from scratch. As the first data hire, I started a modern data platform (Airbyte, Dagster, dbt, BigQuery, Lightdash) that centralized analytics across the company, all powered by AI (OpenCode + Claude).

### Changes
- Rewrote the ALOHAS `summary` to highlight the first-data-hire scope.
- Expanded `highlights` into four concrete bullets (bootstrapped function, platform stack, centralization, AI-assisted delivery).
- Updated `technologies` chips: `Airbyte · Dagster · dbt · BigQuery · Lightdash · OpenCode · Claude`.
- Regenerated `README.md` via `npm run generate:readme`.