### PR TITLE
feat(cv): restructure skills into 5 categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 👨🏻‍💻 About me
 
-Passionate Data Engineer with a strong foundation in data science, shaped by diverse international experiences. Currently contributing at Alohas.com, where I design and implement scalable data and analytics architectures to drive business insights and decision-making.
+Data Engineer with experience across big corporations (Unity Technologies) and startups, spanning both data engineering and analytics engineering. I build scalable data platforms end to end — from ingestion and orchestration to modeling and the semantic layer — and leverage AI-assisted development to deliver high-quality results, fast.
 
 ## 💼 Work Experience
 

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -96,6 +96,9 @@
   keywords: (basics.label,),
 )
 
+// Tighten the gap between the header block and the first section.
+#v(-0.6em)
+
 = Profile
 
 #basics.summary

--- a/cv/modern-cv/lib.typ
+++ b/cv/modern-cv/lib.typ
@@ -481,8 +481,8 @@
 
   let name = {
     align(center)[
-      #pad(bottom: 5pt)[
-        #block[
+      #pad(bottom: 0pt)[
+        #block(below: 0.1em)[
           #set text(size: name-size, style: "normal", font: header-font)
           #if language == "zh" or language == "ja" [
             #text(accent-color, weight: "bold")[#author.lastname]#text(

--- a/resume.json
+++ b/resume.json
@@ -334,47 +334,40 @@
   "publications": [],
   "skills": [
     {
-      "name": "Languages",
+      "name": "AI Development",
       "level": "Advanced",
-      "keywords": ["SQL", "TypeScript", "Python"],
-      "visibility": ["pdf", "website"]
-    },
-    {
-      "name": "Frameworks & technologies",
-      "level": "Advanced",
-      "keywords": ["dbt", "Spark", "Dagster"],
+      "keywords": ["OpenCode", "Claude Code", "Agents", "MCPs", "Skills"],
       "visibility": ["pdf", "website"]
     },
     {
       "name": "Data Engineering",
       "level": "Advanced",
       "keywords": [
-        "dbt",
-        "Snowflake",
-        "Dagster",
         "Apache Spark",
         "Apache Druid",
+        "Dataproc",
+        "Dagster",
         "Airflow"
       ],
-      "visibility": ["website"]
+      "visibility": ["pdf", "website"]
     },
     {
-      "name": "Programming Languages",
+      "name": "Analytics Engineering",
       "level": "Advanced",
-      "keywords": ["SQL", "Python", "JavaScript", "TypeScript"],
-      "visibility": ["website"]
+      "keywords": ["BigQuery", "Snowflake", "dbt", "SQL", "semantic layer"],
+      "visibility": ["pdf", "website"]
+    },
+    {
+      "name": "Data Visualization",
+      "level": "Advanced",
+      "keywords": ["Lightdash", "Looker"],
+      "visibility": ["pdf", "website"]
     },
     {
       "name": "Cloud & Infrastructure",
       "level": "Advanced",
       "keywords": ["GCP", "Terraform"],
-      "visibility": ["website"]
-    },
-    {
-      "name": "Analytics & Tools",
-      "level": "Intermediate",
-      "keywords": ["Tableau", "Jest", "OpenAPI"],
-      "visibility": ["website"]
+      "visibility": ["pdf", "website"]
     }
   ],
   "languages": [

--- a/resume.json
+++ b/resume.json
@@ -35,7 +35,7 @@
       "location": "Barcelona, Catalonia, Spain",
       "url": "https://github.com/ALOHAS2020",
       "startDate": "2025-03-01",
-      "summary": "Built data capabilities in the company from scratch. As the first data hire, I started a modern data platform (Airbyte, Dagster, dbt, BigQuery, Lightdash) that centralized analytics across the company, all powered by AI (OpenCode + Claude).",
+      "summary": "Built data capabilities in the company from scratch. As the first data hire, I started a modern data platform that centralized analytics across the company, all powered by AI.",
       "highlights": [
         "First data hire — bootstrapped the entire data function from scratch",
         "Built a modern data platform with Airbyte, Dagster, dbt, BigQuery, and Lightdash",

--- a/resume.json
+++ b/resume.json
@@ -7,7 +7,7 @@
     "email": "cristian@abrante.me",
     "phone": "+34 634 682 893",
     "url": "https://cristianabrante.com",
-    "summary": "Passionate Data Engineer with a strong foundation in data science, shaped by diverse international experiences. Currently contributing at Alohas.com, where I design and implement scalable data and analytics architectures to drive business insights and decision-making.",
+    "summary": "Data Engineer with experience across big corporations (Unity Technologies) and startups, spanning both data engineering and analytics engineering. I build scalable data platforms end to end, from ingestion and orchestration to modeling and the semantic layer, and leverage AI-assisted development to deliver high-quality results.",
     "location": {
       "address": "",
       "postalCode": "",
@@ -42,7 +42,15 @@
         "Centralized analytics across the company to enable data-driven decision-making",
         "Leveraged AI-assisted development (OpenCode + Claude) to accelerate delivery"
       ],
-      "technologies": ["Airbyte", "Dagster", "dbt", "BigQuery", "Lightdash", "OpenCode", "Claude"],
+      "technologies": [
+        "Airbyte",
+        "Dagster",
+        "dbt",
+        "BigQuery",
+        "Lightdash",
+        "OpenCode",
+        "Claude"
+      ],
       "logo": "logos/alohas.png",
       "visibility": ["readme", "pdf", "website"]
     },
@@ -327,7 +335,7 @@
       "date": "2019-04-01",
       "awarder": "Oficina de Software Libre - Universidad de La Laguna",
       "summary": "Special award for best project in the local phase of the Spanish University free software contest, given to the project GeneticJS.",
-      "visibility": ["pdf", "website"]
+      "visibility": ["website"]
     }
   ],
   "certificates": [],
@@ -374,12 +382,12 @@
     {
       "language": "Spanish",
       "fluency": "Native speaker",
-      "visibility": ["pdf", "website"]
+      "visibility": ["website"]
     },
     {
       "language": "English",
       "fluency": "Full professional proficiency",
-      "visibility": ["pdf", "website"]
+      "visibility": ["website"]
     }
   ],
   "interests": [],


### PR DESCRIPTION
Restructured the skills section in resume.json into 5 new categories:

**New Skill Categories:**
- AI Development (OpenCode, Claude Code, Agents, MCPs, Skills)
- Data Engineering (Apache Spark, Apache Druid, Dataproc, Dagster, Airflow)
- Analytics Engineering (BigQuery, Snowflake, dbt, SQL, semantic layer)
- Data Visualization (Lightdash, Looker)
- Cloud & Infrastructure (GCP, Terraform)

**Removed Legacy Sections:**
- Languages
- Programming Languages
- Frameworks & technologies
- Analytics & Tools

All new sections now have visibility set to both 'pdf' and 'website'.