### PR TITLE
fix(ci): stop adding gitignored website/output in sync-resume workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,7 @@ Automatically generates and updates all resume formats when `resume.json` change
 2. **Generates Website**
    - Runs `npm run generate:website`
    - Creates HTML, CSS, and JS files in `website/output/`
-   - Commits website files to repository if changed
+   - Output is gitignored; deployment happens via the `deploy-website.yml` workflow (GitHub Pages)
 
 3. **Compiles PDF with Typst**
    - Installs Typst via `typst-community/setup-typst@v5` (with package caching)

--- a/.github/workflows/sync-resume.yml
+++ b/.github/workflows/sync-resume.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          if git diff --quiet README.md website/; then
+          if git diff --quiet README.md; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -60,8 +60,8 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add README.md website/output/
-          git commit -m "chore: auto-update README.md and website from resume.json [skip ci]"
+          git add README.md
+          git commit -m "chore: auto-update README.md from resume.json [skip ci]"
           git push origin HEAD:${{ github.head_ref || github.ref_name }}
 
       - name: Get version from resume.json


### PR DESCRIPTION
## Problem
The sync-resume workflow was failing at the 'Commit and push changes if any' step.

## Root Cause
The workflow was attempting to run `git add README.md website/output/`, but `website/output/` is now gitignored (website deploys via GitHub Pages). This caused git to exit with status 1, failing the workflow step.

## Solution
- Updated the check step to diff only README.md (not website/output/)
- Updated the commit step to add only README.md
- Updated the commit message to reflect README-only changes
- Updated workflow documentation to clarify that website output is gitignored and deployed via deploy-website.yml